### PR TITLE
Fix wrong port exposed in dev container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7
-EXPOSE 80
-ENV PORT=80
+EXPOSE 8000
+ENV PORT=8000
 ENV PATH="${PATH}:/app"
 
 COPY requirements.txt /tmp/requirements.txt

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,6 +2,7 @@ version: '3'
 
 services:
   web:
+    image: rcja-registration:development
     build: .
     ports:
       - 8000:8000

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
   web:
     restart: unless-stopped
+    image: rcja-registration:production
     build:
       context: .
       dockerfile: Dockerfile.production


### PR DESCRIPTION
The wrong port was exposed on the dev container side. Also the development and production images have been given different tags to distinguish them in dev.