### PR TITLE
add margin to a4 pagesize to give invoice borders ( closes #128)

### DIFF
--- a/rcjaRegistration/templates/invoices/invoiceDetail.html
+++ b/rcjaRegistration/templates/invoices/invoiceDetail.html
@@ -162,9 +162,10 @@
 
 
 <style>
+
   @page {
     size: A4;
-    margin: 0;
+    margin: 2%;
   }
 
   @media print {


### PR DESCRIPTION
Needs to be tested across browsers because this is something that's implemented somewhat inconsistently 

- tested on my chrome and Firefox on latest linux at the very least