### PR TITLE
add placeholder to login form and add more verbose login text (closes #177)

### DIFF
--- a/rcjaRegistration/rcjaRegistration/forms.py
+++ b/rcjaRegistration/rcjaRegistration/forms.py
@@ -1,0 +1,8 @@
+from django import forms
+from django.contrib.auth.forms import AuthenticationForm
+from django.forms.widgets import PasswordInput, TextInput
+
+
+class CustomAuthForm(AuthenticationForm):
+    username = forms.CharField(widget=TextInput(attrs={'class':'validate','placeholder': 'Email Address'}))
+    password = forms.CharField(widget=PasswordInput(attrs={'placeholder':'Password'}))

--- a/rcjaRegistration/rcjaRegistration/urls.py
+++ b/rcjaRegistration/rcjaRegistration/urls.py
@@ -17,7 +17,8 @@ from django.conf.urls import include, url
 from django.contrib import admin
 from django.urls import path, include
 from django.views.generic.base import RedirectView
-
+from django.contrib.auth import views as auth_views
+from .forms import CustomAuthForm
 admin.site.site_header = "RCJA Admin"
 admin.site.site_title = "RCJA Admin Portal"
 admin.site.index_title = "Welcome to the RCJA Admin Portal"
@@ -25,6 +26,8 @@ admin.site.index_title = "Welcome to the RCJA Admin Portal"
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('accounts/login/', auth_views.LoginView.as_view(
+        template_name='registration/login.html', authentication_form=CustomAuthForm)),
     path('accounts/', include('django.contrib.auth.urls')), #login
     # path('api/v1/', include('apiv1.urls')), # Disabled for initial release
     path('', include('events.urls')),

--- a/rcjaRegistration/templates/registration/login.html
+++ b/rcjaRegistration/templates/registration/login.html
@@ -47,8 +47,9 @@
         <div class="form-group ">
           <div>
             <h1> Robocup Australia</h1>
-            <h5> Mentor login or signup</h5>
-            <h4>Please Login</h4>
+            <h3>Event and Workshop Registration System </h3>
+            <h4> Please Login, or Create an Account Below </h4>
+            <h5> For assistance, please contact us on <a href="https://github.com/MelbourneHighSchoolRobotics/RCJA_Registration_System"> Github </a> </h5>
             {% if form.errors %}
             <!-- Error messaging -->
             <div class="ui warning message left-aligned-text">


### PR DESCRIPTION
Decided to put github as placeholder for actual contact help info.