### PR TITLE
Make P/O modal enter button submit via jQuery rather than HTML form (closes #116)

### DIFF
--- a/rcjaRegistration/templates/invoices/summary.html
+++ b/rcjaRegistration/templates/invoices/summary.html
@@ -87,7 +87,7 @@
                 <label>Number</label>
                 <input name = "PONumber" class = "ui input"> </input>
             </div>
-          </form>
+         </form>
         </div>
     </div>
     <div class="actions">
@@ -95,7 +95,7 @@
         Cancel
         </div>
 
-        <button id = "confirm" class="ui positive right button">
+        <button id = "confirm-po" class="ui positive right button">
         Set Number
         </button>
     </div>
@@ -116,13 +116,24 @@
         Cancel
         </div>
 
-        <button id = "confirm" class="ui positive right button">
+        <button id = "confirm-campus" class="ui positive right button">
         Enable campus invoicing
         </button>
     </div>
 </div>
     
 <script> 
+
+$('.poNumber').keypress(function(e){
+    var code = e.keyCode || e.which;
+
+    if( code === 13 ) {
+        e.preventDefault();
+        $( "#confirm-po" ).click();
+    };
+});
+
+
     function showPOModal(invoiceNumber) {
         $('#invoiceNumber').val(invoiceNumber)
         $('.ui.modal.poNumber').modal({


### PR DESCRIPTION
Note that this behaviour must be manually enabled for each modal - default behaviour is to not override enter key. In some cases this is preferable (e.g. with set campus, you don't want an accidental enter press to do an irrevocable action).